### PR TITLE
Support strings localization.

### DIFF
--- a/app/src/main/java/com/tick/taku/notificationwatcher/MainActivity.kt
+++ b/app/src/main/java/com/tick/taku/notificationwatcher/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.tick.taku.notificationwatcher
 
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.provider.Settings
 import androidx.annotation.IdRes
@@ -23,6 +22,7 @@ import com.tick.taku.android.corecomponent.di.FragmentScope
 import com.tick.taku.android.corecomponent.ktx.dataBinding
 import com.tick.taku.android.corecomponent.ktx.getBinding
 import com.tick.taku.android.corecomponent.ktx.viewModelProvider
+import com.tick.taku.android.corecomponent.ui.BaseActivity
 import com.tick.taku.android.corecomponent.util.showDialog
 import com.tick.taku.notificationwatcher.databinding.ActivityMainBinding
 import com.tick.taku.notificationwatcher.databinding.LayoutDrawerHeaderBinding
@@ -42,7 +42,7 @@ import onactivityresult.ActivityResult
 import javax.inject.Inject
 import javax.inject.Provider
 
-class MainActivity : AppCompatActivity(R.layout.activity_main), HasAndroidInjector {
+class MainActivity : BaseActivity(R.layout.activity_main), HasAndroidInjector {
 
     @Inject lateinit var injector: DispatchingAndroidInjector<Any>
     override fun androidInjector(): AndroidInjector<Any> = injector

--- a/app/src/main/java/com/tick/taku/notificationwatcher/MyApplication.kt
+++ b/app/src/main/java/com/tick/taku/notificationwatcher/MyApplication.kt
@@ -1,7 +1,9 @@
 package com.tick.taku.notificationwatcher
 
+import android.content.SharedPreferences
 import coil.Coil
 import coil.ImageLoader
+import com.tick.taku.android.corecomponent.di.DirectlyModuleProvider
 import com.tick.taku.notificationwatcher.di.AppComponent
 import com.tick.taku.notificationwatcher.di.AppInjector
 import com.tick.taku.notificationwatcher.di.createAppComponent
@@ -10,7 +12,7 @@ import dagger.android.DaggerApplication
 import timber.log.Timber
 import javax.inject.Inject
 
-class MyApplication: DaggerApplication() {
+class MyApplication: DaggerApplication(), DirectlyModuleProvider {
 
     private val appComponent: AppComponent by lazy {
         createAppComponent()
@@ -32,5 +34,8 @@ class MyApplication: DaggerApplication() {
         Coil.setDefaultImageLoader(imageLoader)
         Timber.plant(logTree)
     }
+
+    @Inject lateinit var prefs: SharedPreferences
+    override fun providerSharedPrefs(): SharedPreferences = prefs
 
 }

--- a/app/src/main/res/values-ja/strings-ja.xml
+++ b/app/src/main/res/values-ja/strings-ja.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Menu -->
+    <string name="account_link">アカウントリンク</string>
+    <string name="menu_settings">設定</string>
+
+    <!-- Dialog -->
+    <string name="ok">OK</string>
+    <string name="cancel">キャンセル</string>
+    <string name="notification_listener_denied">LINE からの通知を受け取るためにアプリに権限を許可してください。</string>
+
+    <string name="already_logged_in">すでに LINE アカウントでログインされています。ログアウトしますか？</string>
+    <string name="logout">ログアウト</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,12 @@
 <resources>
-    <string name="app_name">NotificationWatcher</string>
+    <string name="app_name" translatable="false">NotificationWatcher</string>
 
     <!-- Menu -->
     <string name="account_link">Account Link</string>
     <string name="menu_settings">Settings</string>
-    <string name="content_description_drawer_header">Header</string>
-    <string name="content_description_drawer_icon">Icon</string>
+
+    <string name="content_description_drawer_header" translatable="false">Header</string>
+    <string name="content_description_drawer_icon" translatable="false">Icon</string>
 
     <!-- Dialog -->
     <string name="ok">OK</string>

--- a/corecomponent/src/main/java/com/tick/taku/android/corecomponent/di/DirectlyModuleProvider.kt
+++ b/corecomponent/src/main/java/com/tick/taku/android/corecomponent/di/DirectlyModuleProvider.kt
@@ -1,0 +1,8 @@
+package com.tick.taku.android.corecomponent.di
+
+import android.content.SharedPreferences
+
+// TODO: For get injection on attachBaseContext.
+interface DirectlyModuleProvider {
+    fun providerSharedPrefs(): SharedPreferences
+}

--- a/corecomponent/src/main/java/com/tick/taku/android/corecomponent/ui/BaseActivity.kt
+++ b/corecomponent/src/main/java/com/tick/taku/android/corecomponent/ui/BaseActivity.kt
@@ -1,0 +1,55 @@
+package com.tick.taku.android.corecomponent.ui
+
+import android.annotation.TargetApi
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
+import androidx.annotation.LayoutRes
+import androidx.appcompat.app.AppCompatActivity
+import com.tick.taku.android.corecomponent.R
+import com.tick.taku.android.corecomponent.di.DirectlyModuleProvider
+import com.tick.taku.android.corecomponent.ktx.guard
+import java.util.*
+
+abstract class BaseActivity(@LayoutRes layoutId: Int): AppCompatActivity(layoutId) {
+
+    override fun attachBaseContext(base: Context?) {
+        val conf = Configuration(base?.resources?.configuration).apply {
+            setLocale(getLocale(base))
+        }
+        super.attachBaseContext(base?.createConfigurationContext(conf))
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        val currentLocale =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) getCurrentLocale()
+            else getCurrentLocaleLegacy()
+        if (currentLocale != getLocale(this)) {
+            recreate()
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.N)
+    private fun getCurrentLocale() = resources.configuration.locales.get(0)
+
+    @Suppress("deprecation")
+    private fun getCurrentLocaleLegacy() = resources.configuration.locale
+
+    private fun getLocale(context: Context?): Locale {
+        val pref = (context?.applicationContext as? DirectlyModuleProvider)?.providerSharedPrefs() guard {
+            return Locale.getDefault()
+        }
+
+        val (key, value) = context!!.let {
+            it.getString(R.string.pref_key_language) to it.getString(R.string.localized_language_value_system)
+        }
+        return when (pref.getString(key, value)) {
+            context.getString(R.string.localized_language_value_en) -> Locale.ENGLISH
+            context.getString(R.string.localized_language_value_ja) -> Locale.JAPANESE
+            else -> Locale.getDefault()
+        }
+    }
+
+}

--- a/corecomponent/src/main/res/values/pref_default.xml
+++ b/corecomponent/src/main/res/values/pref_default.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <bool name="is_show_url_preview">true</bool>
+    <bool name="is_enabled_auto_delete">false</bool>
     <integer name="delete_from_min">1</integer>
     <integer name="delete_from_max">12</integer>
 </resources>

--- a/corecomponent/src/main/res/values/pref_default.xml
+++ b/corecomponent/src/main/res/values/pref_default.xml
@@ -5,10 +5,12 @@
     <integer name="delete_from_min">1</integer>
     <integer name="delete_from_max">12</integer>
 
-    <string name="language">0</string>
+    <string name="localized_language_value_system">0</string>
+    <string name="localized_language_value_en">1</string>
+    <string name="localized_language_value_ja">2</string>
     <string-array name="localized_language_values">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
+        <item>@string/localized_language_value_system</item>
+        <item>@string/localized_language_value_en</item>
+        <item>@string/localized_language_value_ja</item>
     </string-array>
 </resources>

--- a/corecomponent/src/main/res/values/pref_default.xml
+++ b/corecomponent/src/main/res/values/pref_default.xml
@@ -4,4 +4,11 @@
     <bool name="is_enabled_auto_delete">false</bool>
     <integer name="delete_from_min">1</integer>
     <integer name="delete_from_max">12</integer>
+
+    <string name="language">0</string>
+    <string-array name="localized_language_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
 </resources>

--- a/corecomponent/src/main/res/values/pref_keys.xml
+++ b/corecomponent/src/main/res/values/pref_keys.xml
@@ -6,4 +6,7 @@
     <string name="pref_key_auto_delete">auto_delete</string>
     <string name="pref_key_enable_auto_delete">enable_auto_delete</string>
     <string name="pref_key_delete_from">delete_from</string>
+
+    <string name="pref_key_system">system</string>
+    <string name="pref_key_language">selected_language</string>
 </resources>

--- a/feature/message/src/main/res/values-ja/strings-ja.xml
+++ b/feature/message/src/main/res/values-ja/strings-ja.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="msg_confirmation_delete_room">削除しますか?</string>
+
+    <string name="copy_to_clipboard">クリップボードにコピーしました。</string>
+
+    <!-- Dialog -->
+    <string name="ok">OK</string>
+    <string name="cancel">キャンセル</string>
+</resources>

--- a/feature/message/src/main/res/values-ja/strings_toolbar-ja.xml
+++ b/feature/message/src/main/res/values-ja/strings_toolbar-ja.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="toolbar_room_list">ルーム</string>
+    <string name="toolbar_message_default">メッセージ</string>
+</resources>

--- a/feature/message/src/main/res/values/strings.xml
+++ b/feature/message/src/main/res/values/strings.xml
@@ -2,12 +2,12 @@
     <!-- Room List -->
     <string name="msg_confirmation_delete_room">Are you sure you want to erase it?</string>
 
-    <string name="posted_room_date_format" translatable="false">yyyy/MM/dd HH:mm</string>
-
     <!-- Message Screen -->
     <string name="clipboard_label_message" translatable="false">message</string>
     <string name="copy_to_clipboard">Message copied to clipboard.</string>
 
+    <!-- Format -->
+    <string name="posted_room_date_format" translatable="false">yyyy/MM/dd HH:mm</string>
     <string name="grouping_date_format" translatable="false">yyyy/MM/dd (EE)</string>
     <string name="posted_message_date_format" translatable="false">HH:mm</string>
 

--- a/feature/message/src/main/res/values/strings.xml
+++ b/feature/message/src/main/res/values/strings.xml
@@ -1,21 +1,17 @@
 <resources>
-    <string name="app_name">NotificationWatcher</string>
-
     <!-- Room List -->
     <string name="msg_confirmation_delete_room">Are you sure you want to erase it?</string>
 
-    <string name="posted_room_date_format">yyyy/MM/dd HH:mm</string>
+    <string name="posted_room_date_format" translatable="false">yyyy/MM/dd HH:mm</string>
 
     <!-- Message Screen -->
-    <string name="clipboard_label_message">message</string>
+    <string name="clipboard_label_message" translatable="false">message</string>
     <string name="copy_to_clipboard">Message copied to clipboard.</string>
 
-    <string name="grouping_date_format">yyyy/MM/dd (EE)</string>
-
-    <string name="posted_message_date_format">HH:mm</string>
+    <string name="grouping_date_format" translatable="false">yyyy/MM/dd (EE)</string>
+    <string name="posted_message_date_format" translatable="false">HH:mm</string>
 
     <!-- Dialog -->
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
-    <string name="notification_listener_denied">Permission not granted. Please setup.</string>
 </resources>

--- a/feature/preference/src/main/java/com/tick/taku/notificationwatcher/view/preference/PreferencesActivity.kt
+++ b/feature/preference/src/main/java/com/tick/taku/notificationwatcher/view/preference/PreferencesActivity.kt
@@ -2,13 +2,13 @@ package com.tick.taku.notificationwatcher.view.preference
 
 import android.content.Context
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
 import com.tick.taku.android.corecomponent.ktx.dataBinding
 import com.tick.taku.android.corecomponent.ktx.openActivity
+import com.tick.taku.android.corecomponent.ui.BaseActivity
 import com.tick.taku.notificationwatcher.view.preference.databinding.ActivityPreferencesBinding
 import dagger.Module
 import dagger.android.AndroidInjector
@@ -17,7 +17,7 @@ import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import javax.inject.Inject
 
-class PreferencesActivity: AppCompatActivity(R.layout.activity_preferences), HasAndroidInjector {
+class PreferencesActivity: BaseActivity(R.layout.activity_preferences), HasAndroidInjector {
 
     @Inject lateinit var injector: DispatchingAndroidInjector<Any>
     override fun androidInjector(): AndroidInjector<Any> = injector

--- a/feature/preference/src/main/java/com/tick/taku/notificationwatcher/view/preference/PreferencesFragment.kt
+++ b/feature/preference/src/main/java/com/tick/taku/notificationwatcher/view/preference/PreferencesFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.lifecycle.observe
 import androidx.preference.*
 import com.tick.taku.android.corecomponent.di.Injectable
+import com.tick.taku.android.corecomponent.ktx.guard
 import com.tick.taku.android.corecomponent.ktx.viewModelProvider
 import com.tick.taku.notificationwatcher.view.preference.viewmodel.PreferencesViewModel
 import javax.inject.Inject
@@ -24,7 +25,9 @@ class PreferencesFragment: PreferenceFragmentCompat(), Injectable {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        preferenceManager?.findPreference<SwitchPreferenceCompat>(getString(R.string.pref_key_enable_auto_delete))?.let {
+        preferenceManager guard { return }
+
+        preferenceManager.findPreference<SwitchPreferenceCompat>(getString(R.string.pref_key_enable_auto_delete))?.let {
             viewModel.setIsEnabledAutoDelete(it.isChecked)
             it.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
                 viewModel.setIsEnabledAutoDelete(newValue as Boolean)
@@ -35,6 +38,13 @@ class PreferencesFragment: PreferenceFragmentCompat(), Injectable {
         viewModel.isEnabledAutoDelete.observe(viewLifecycleOwner) { isEnabled ->
             preferenceManager?.findPreference<SeekBarPreference>(getString(R.string.pref_key_delete_from))?.let {
                 it.isEnabled = isEnabled
+            }
+        }
+
+        preferenceManager.findPreference<ListPreference>(getString(R.string.pref_key_language))?.let {
+            it.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, _ ->
+                activity?.recreate()
+                return@OnPreferenceChangeListener true
             }
         }
     }

--- a/feature/preference/src/main/java/com/tick/taku/notificationwatcher/view/preference/PreferencesFragment.kt
+++ b/feature/preference/src/main/java/com/tick/taku/notificationwatcher/view/preference/PreferencesFragment.kt
@@ -42,8 +42,12 @@ class PreferencesFragment: PreferenceFragmentCompat(), Injectable {
         }
 
         preferenceManager.findPreference<ListPreference>(getString(R.string.pref_key_language))?.let {
-            it.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, _ ->
-                activity?.recreate()
+            var prev = it.value
+            it.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+                if (prev != (newValue as String)) {
+                    activity?.recreate()
+                }
+                prev = newValue
                 return@OnPreferenceChangeListener true
             }
         }

--- a/feature/preference/src/main/res/values-ja/strings-ja.xml
+++ b/feature/preference/src/main/res/values-ja/strings-ja.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="toolbar_title_settings">設定</string>
+
+    <string name="message_category">メッセージ</string>
+    <string name="enable_url_preview">URLプレビュー</string>
+
+    <string name="auto_delete_category">自動メッセージ削除</string>
+    <string name="enable_auto_delete">保存期間外のメッセージを自動で削除する</string>
+    <string name="delete_from">保存期間</string>
+    <string name="delete_from_summary">メッセージを保存する期間を指定してください。</string>
+</resources>

--- a/feature/preference/src/main/res/values-ja/strings-ja.xml
+++ b/feature/preference/src/main/res/values-ja/strings-ja.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="toolbar_title_settings">設定</string>
 
+    <!-- Message -->
     <string name="message_category">メッセージ</string>
 
     <string name="show_url_preview">URLプレビュー</string>
@@ -11,4 +12,12 @@
     <string name="summary_auto_delete">保存期間外のメッセージを自動で削除します。</string>
     <string name="delete_from">保存期間 (月)</string>
     <string name="delete_from_summary">メッセージを保存する期間を指定してください。</string>
+
+    <!-- System -->
+    <string name="system_category">システム</string>
+    <string name="select_language">言語設定</string>
+
+    <string name="localized_en">英語</string>
+    <string name="localized_ja">日本語</string>
+    <string name="localized_auto">システム</string>
 </resources>

--- a/feature/preference/src/main/res/values-ja/strings-ja.xml
+++ b/feature/preference/src/main/res/values-ja/strings-ja.xml
@@ -3,10 +3,12 @@
     <string name="toolbar_title_settings">設定</string>
 
     <string name="message_category">メッセージ</string>
-    <string name="enable_url_preview">URLプレビュー</string>
 
-    <string name="auto_delete_category">自動メッセージ削除</string>
-    <string name="enable_auto_delete">保存期間外のメッセージを自動で削除する</string>
-    <string name="delete_from">保存期間</string>
+    <string name="show_url_preview">URLプレビュー</string>
+    <string name="summary_url_preview">メッセージ内の Web URL のプレビューを表示します。</string>
+
+    <string name="auto_delete">メッセージ自動削除</string>
+    <string name="summary_auto_delete">保存期間外のメッセージを自動で削除します。</string>
+    <string name="delete_from">保存期間 (月)</string>
     <string name="delete_from_summary">メッセージを保存する期間を指定してください。</string>
 </resources>

--- a/feature/preference/src/main/res/values/strings.xml
+++ b/feature/preference/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="toolbar_title_settings">Settings</string>
 
+    <!-- Message -->
     <string name="message_category">Message</string>
 
     <string name="show_url_preview">URL preview</string>
@@ -11,4 +12,17 @@
     <string name="summary_auto_delete">Messages outside the retention period are automatically deleted.</string>
     <string name="delete_from">How old</string>
     <string name="delete_from_summary">How many months old message will be erased?</string>
+
+    <!-- System -->
+    <string name="system_category">System</string>
+    <string name="select_language">Select language</string>
+
+    <string name="localized_en">English</string>
+    <string name="localized_ja">Japanese</string>
+    <string name="localized_auto">System</string>
+    <string-array name="localized_language">
+        <item>@string/localized_auto</item>
+        <item>@string/localized_en</item>
+        <item>@string/localized_ja</item>
+    </string-array>
 </resources>

--- a/feature/preference/src/main/res/values/strings.xml
+++ b/feature/preference/src/main/res/values/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="toolbar_title_settings">Settings</string>
 
-    <string name="enable_summary_on">Enabled</string>
-    <string name="enable_summary_off">Disabled</string>
-
     <string name="message_category">Message</string>
     <string name="enable_url_preview">Enable URL preview</string>
 

--- a/feature/preference/src/main/res/values/strings.xml
+++ b/feature/preference/src/main/res/values/strings.xml
@@ -3,10 +3,12 @@
     <string name="toolbar_title_settings">Settings</string>
 
     <string name="message_category">Message</string>
-    <string name="enable_url_preview">Enable URL preview</string>
 
-    <string name="auto_delete_category">Auto Delete</string>
-    <string name="enable_auto_delete">Enable auto delete</string>
-    <string name="delete_from">From</string>
+    <string name="show_url_preview">URL preview</string>
+    <string name="summary_url_preview">Show Web URL preview in message.</string>
+
+    <string name="auto_delete">Auto Delete</string>
+    <string name="summary_auto_delete">Messages outside the retention period are automatically deleted.</string>
+    <string name="delete_from">How old</string>
     <string name="delete_from_summary">How many months old message will be erased?</string>
 </resources>

--- a/feature/preference/src/main/res/xml/preference.xml
+++ b/feature/preference/src/main/res/xml/preference.xml
@@ -8,8 +8,6 @@
         <SwitchPreferenceCompat
             android:key="@string/pref_key_enable_url_preview"
             android:title="@string/enable_url_preview"
-            android:summaryOn="@string/enable_summary_on"
-            android:summaryOff="@string/enable_summary_off"
             android:defaultValue="@bool/is_show_url_preview"/>
 
     </PreferenceCategory>
@@ -20,9 +18,7 @@
 
         <SwitchPreferenceCompat
             android:key="@string/pref_key_enable_auto_delete"
-            android:title="@string/enable_auto_delete"
-            android:summaryOn="@string/enable_summary_on"
-            android:summaryOff="@string/enable_summary_off"/>
+            android:title="@string/enable_auto_delete"/>
 
         <SeekBarPreference
             android:key="@string/pref_key_delete_from"

--- a/feature/preference/src/main/res/xml/preference.xml
+++ b/feature/preference/src/main/res/xml/preference.xml
@@ -27,4 +27,20 @@
             app:showSeekBarValue="true"/>
 
     </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/system_category"
+        android:key="@string/pref_key_system">
+
+        <ListPreference
+            android:title="@string/select_language"
+            android:key="@string/pref_key_language"
+            android:entries="@array/localized_language"
+            android:entryValues="@array/localized_language_values"
+            android:defaultValue="@string/language"
+            android:dialogTitle="@string/select_language"
+            app:useSimpleSummaryProvider="true"/>
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/feature/preference/src/main/res/xml/preference.xml
+++ b/feature/preference/src/main/res/xml/preference.xml
@@ -37,7 +37,7 @@
             android:key="@string/pref_key_language"
             android:entries="@array/localized_language"
             android:entryValues="@array/localized_language_values"
-            android:defaultValue="@string/language"
+            android:defaultValue="@string/localized_language_value_system"
             android:dialogTitle="@string/select_language"
             app:useSimpleSummaryProvider="true"/>
 

--- a/feature/preference/src/main/res/xml/preference.xml
+++ b/feature/preference/src/main/res/xml/preference.xml
@@ -7,18 +7,15 @@
 
         <SwitchPreferenceCompat
             android:key="@string/pref_key_enable_url_preview"
-            android:title="@string/enable_url_preview"
+            android:title="@string/show_url_preview"
+            android:summary="@string/summary_url_preview"
             android:defaultValue="@bool/is_show_url_preview"/>
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        android:title="@string/auto_delete_category"
-        android:key="@string/pref_key_auto_delete">
 
         <SwitchPreferenceCompat
             android:key="@string/pref_key_enable_auto_delete"
-            android:title="@string/enable_auto_delete"/>
+            android:title="@string/auto_delete"
+            android:summary="@string/summary_auto_delete"
+            android:defaultValue="@bool/is_enabled_auto_delete"/>
 
         <SeekBarPreference
             android:key="@string/pref_key_delete_from"


### PR DESCRIPTION
## Issue

close #34 


## Overview

- Support strings localization.
  - ja
  - en

- Change Locale by settings.
  - system
  - ja
  - en
  
- Make DirectlyModuleProvider for getting injected module on Activity.attachBaseContext()
  - Activity.attachBaseContext() is called after attachBaseContext, so can't get injected SharedPreferences for check selected locale.

