### PR TITLE
Change UI mode by settings.

### DIFF
--- a/corecomponent/src/main/java/com/tick/taku/android/corecomponent/ui/BaseActivity.kt
+++ b/corecomponent/src/main/java/com/tick/taku/android/corecomponent/ui/BaseActivity.kt
@@ -20,15 +20,21 @@ abstract class BaseActivity(@LayoutRes layoutId: Int): AppCompatActivity(layoutI
         super.attachBaseContext(base?.createConfigurationContext(conf))
     }
 
+    override fun applyOverrideConfiguration(overrideConfiguration: Configuration?) {
+        overrideConfiguration?.let {
+            val uiMode = it.uiMode
+            it.setTo(baseContext.resources.configuration)
+            it.uiMode = uiMode
+        }
+        super.applyOverrideConfiguration(overrideConfiguration)
+    }
+
     override fun onResume() {
         super.onResume()
-
         val currentLocale =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) getCurrentLocale()
             else getCurrentLocaleLegacy()
-        if (currentLocale != getLocale(this)) {
-            recreate()
-        }
+        if (currentLocale != getLocale()) recreate()
     }
 
     @TargetApi(Build.VERSION_CODES.N)
@@ -37,7 +43,7 @@ abstract class BaseActivity(@LayoutRes layoutId: Int): AppCompatActivity(layoutI
     @Suppress("deprecation")
     private fun getCurrentLocaleLegacy() = resources.configuration.locale
 
-    private fun getLocale(context: Context?): Locale {
+    private fun getLocale(context: Context? = this): Locale {
         val pref = (context?.applicationContext as? DirectlyModuleProvider)?.providerSharedPrefs() guard {
             return Locale.getDefault()
         }

--- a/corecomponent/src/main/java/com/tick/taku/android/corecomponent/ui/BaseActivity.kt
+++ b/corecomponent/src/main/java/com/tick/taku/android/corecomponent/ui/BaseActivity.kt
@@ -31,6 +31,8 @@ abstract class BaseActivity(@LayoutRes layoutId: Int): AppCompatActivity(layoutI
 
     override fun onResume() {
         super.onResume()
+
+        // TODO: Use OnPreferenceChangeListener
         val currentLocale =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) getCurrentLocale()
             else getCurrentLocaleLegacy()

--- a/corecomponent/src/main/java/com/tick/taku/android/corecomponent/ui/BaseActivity.kt
+++ b/corecomponent/src/main/java/com/tick/taku/android/corecomponent/ui/BaseActivity.kt
@@ -15,7 +15,7 @@ abstract class BaseActivity(@LayoutRes layoutId: Int): AppCompatActivity(layoutI
 
     override fun attachBaseContext(base: Context?) {
         val conf = Configuration(base?.resources?.configuration).apply {
-            setLocale(getLocale(base))
+            setLocale(base?.getLocale())
         }
         super.attachBaseContext(base?.createConfigurationContext(conf))
     }
@@ -43,17 +43,17 @@ abstract class BaseActivity(@LayoutRes layoutId: Int): AppCompatActivity(layoutI
     @Suppress("deprecation")
     private fun getCurrentLocaleLegacy() = resources.configuration.locale
 
-    private fun getLocale(context: Context? = this): Locale {
-        val pref = (context?.applicationContext as? DirectlyModuleProvider)?.providerSharedPrefs() guard {
+    private fun Context.getLocale(): Locale {
+        val pref = (applicationContext as? DirectlyModuleProvider)?.providerSharedPrefs() guard {
             return Locale.getDefault()
         }
 
-        val (key, value) = context!!.let {
-            it.getString(R.string.pref_key_language) to it.getString(R.string.localized_language_value_system)
+        val (key, value) = run {
+            getString(R.string.pref_key_language) to getString(R.string.localized_language_value_system)
         }
         return when (pref.getString(key, value)) {
-            context.getString(R.string.localized_language_value_en) -> Locale.ENGLISH
-            context.getString(R.string.localized_language_value_ja) -> Locale.JAPANESE
+            getString(R.string.localized_language_value_en) -> Locale.ENGLISH
+            getString(R.string.localized_language_value_ja) -> Locale.JAPANESE
             else -> Locale.getDefault()
         }
     }

--- a/corecomponent/src/main/res/values/pref_default.xml
+++ b/corecomponent/src/main/res/values/pref_default.xml
@@ -13,4 +13,14 @@
         <item>@string/localized_language_value_en</item>
         <item>@string/localized_language_value_ja</item>
     </string-array>
+
+    <string name="ui_mode_value_system">0</string>
+    <string name="ui_mode_value_light">1</string>
+    <string name="ui_mode_value_dark">2</string>
+    <string-array name="ui_mode_value">
+        <item>@string/ui_mode_value_system</item>
+        <item>@string/ui_mode_value_light</item>
+        <item>@string/ui_mode_value_dark</item>
+    </string-array>
+
 </resources>

--- a/corecomponent/src/main/res/values/pref_keys.xml
+++ b/corecomponent/src/main/res/values/pref_keys.xml
@@ -9,4 +9,5 @@
 
     <string name="pref_key_system">system</string>
     <string name="pref_key_language">selected_language</string>
+    <string name="pref_key_ui_mode">ui_mode</string>
 </resources>

--- a/feature/preference/src/main/java/com/tick/taku/notificationwatcher/view/preference/PreferencesFragment.kt
+++ b/feature/preference/src/main/java/com/tick/taku/notificationwatcher/view/preference/PreferencesFragment.kt
@@ -2,6 +2,7 @@ package com.tick.taku.notificationwatcher.view.preference
 
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.observe
 import androidx.preference.*
 import com.tick.taku.android.corecomponent.di.Injectable
@@ -51,6 +52,19 @@ class PreferencesFragment: PreferenceFragmentCompat(), Injectable {
                 return@OnPreferenceChangeListener true
             }
         }
+
+        preferenceManager.findPreference<ListPreference>(getString(R.string.pref_key_ui_mode))?.let {
+            it.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+                AppCompatDelegate.setDefaultNightMode((newValue as String).uiMode())
+                return@OnPreferenceChangeListener true
+            }
+        }
+    }
+
+    private fun String.uiMode(): Int = when (this) {
+        getString(R.string.ui_mode_value_light) -> AppCompatDelegate.MODE_NIGHT_NO
+        getString(R.string.ui_mode_value_dark) -> AppCompatDelegate.MODE_NIGHT_YES
+        else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
     }
 
 }

--- a/feature/preference/src/main/res/values-ja/strings-ja.xml
+++ b/feature/preference/src/main/res/values-ja/strings-ja.xml
@@ -15,9 +15,14 @@
 
     <!-- System -->
     <string name="system_category">システム</string>
-    <string name="select_language">言語設定</string>
 
+    <string name="select_language">言語設定</string>
+    <string name="localized_auto">システム</string>
     <string name="localized_en">英語</string>
     <string name="localized_ja">日本語</string>
-    <string name="localized_auto">システム</string>
+
+    <string name="select_ui_mode">UI設定</string>
+    <string name="ui_mode_system">システム</string>
+    <string name="ui_mode_light">ライト</string>
+    <string name="ui_mode_dark">ダーク</string>
 </resources>

--- a/feature/preference/src/main/res/values/strings.xml
+++ b/feature/preference/src/main/res/values/strings.xml
@@ -15,14 +15,25 @@
 
     <!-- System -->
     <string name="system_category">System</string>
-    <string name="select_language">Select language</string>
 
+    <string name="select_language">Select language</string>
+    <string name="localized_auto">System</string>
     <string name="localized_en">English</string>
     <string name="localized_ja">Japanese</string>
-    <string name="localized_auto">System</string>
     <string-array name="localized_language">
         <item>@string/localized_auto</item>
         <item>@string/localized_en</item>
         <item>@string/localized_ja</item>
     </string-array>
+
+    <string name="select_ui_mode">Select UI</string>
+    <string name="ui_mode_system">System</string>
+    <string name="ui_mode_light">Light</string>
+    <string name="ui_mode_dark">Dark</string>
+    <string-array name="ui_mode">
+        <item>@string/ui_mode_system</item>
+        <item>@string/ui_mode_light</item>
+        <item>@string/ui_mode_dark</item>
+    </string-array>
+
 </resources>

--- a/feature/preference/src/main/res/xml/preference.xml
+++ b/feature/preference/src/main/res/xml/preference.xml
@@ -41,6 +41,15 @@
             android:dialogTitle="@string/select_language"
             app:useSimpleSummaryProvider="true"/>
 
+        <ListPreference
+            android:title="@string/select_ui_mode"
+            android:key="@string/pref_key_ui_mode"
+            android:entries="@array/ui_mode"
+            android:entryValues="@array/ui_mode_value"
+            android:defaultValue="@string/ui_mode_value_system"
+            android:dialogTitle="@string/select_ui_mode"
+            app:useSimpleSummaryProvider="true"/>
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
## Issue

close #40 


## Overview

- Create UI mode select at prefs.
  - System
  - Dark
  - Light


- AppCompatDelegate.setDefaultNightMode() is override configuration.
  - getCurrentLocale returns default.
    - Set up baseContext.resources.configuration to new Configuration at Activity.applyOverrideConfiguration().

[android - configuration.setLocale(locale) doesn't work with AppCompatDelegate.setDefaultNightMode - Stack Overflow](https://stackoverflow.com/questions/57973627/configuration-setlocalelocale-doesnt-work-with-appcompatdelegate-setdefaultni)