### PR TITLE
Add LINE privacy link on PreferenceScreen.

### DIFF
--- a/corecomponent/src/main/res/values/pref_keys.xml
+++ b/corecomponent/src/main/res/values/pref_keys.xml
@@ -7,6 +7,8 @@
     <string name="pref_key_enable_auto_delete">enable_auto_delete</string>
     <string name="pref_key_delete_from">delete_from</string>
 
+    <string name="pref_key_improve_notification_save_accuracy">improve_notification_save_accuracy</string>
+
     <string name="pref_key_system">system</string>
     <string name="pref_key_language">selected_language</string>
     <string name="pref_key_ui_mode">ui_mode</string>

--- a/feature/preference/src/main/res/values-ja/strings-ja.xml
+++ b/feature/preference/src/main/res/values-ja/strings-ja.xml
@@ -13,6 +13,9 @@
     <string name="delete_from">保存期間 (月)</string>
     <string name="delete_from_summary">メッセージを保存する期間を指定してください。</string>
 
+    <string name="improve_notification_save_accuracy">メッセージ保存の精度を向上させる</string>
+    <string name="improve_notification_save_accuracy_summary">LINE の Letter Sealing を OFF にする事でメッセージ保存の精度を向上させます</string>
+
     <!-- System -->
     <string name="system_category">システム</string>
 

--- a/feature/preference/src/main/res/values/strings.xml
+++ b/feature/preference/src/main/res/values/strings.xml
@@ -13,6 +13,9 @@
     <string name="delete_from">How old</string>
     <string name="delete_from_summary">How many months old message will be erased?</string>
 
+    <string name="improve_notification_save_accuracy">Improve accuracy of saving messages</string>
+    <string name="improve_notification_save_accuracy_summary">Improve the message acquisition accuracy by turning off the LINE Letter function.</string>
+
     <!-- System -->
     <string name="system_category">System</string>
 
@@ -35,5 +38,8 @@
         <item>@string/ui_mode_light</item>
         <item>@string/ui_mode_dark</item>
     </string-array>
+
+    <!-- URL -->
+    <string name="line_privacy_url" translatable="false">https://line.me/R/nv/settings/privacy</string>
 
 </resources>

--- a/feature/preference/src/main/res/xml/preference.xml
+++ b/feature/preference/src/main/res/xml/preference.xml
@@ -26,6 +26,15 @@
             android:max="@integer/delete_from_max"
             app:showSeekBarValue="true"/>
 
+        <Preference
+            android:key="@string/pref_key_improve_notification_save_accuracy"
+            android:title="@string/improve_notification_save_accuracy"
+            android:summary="@string/improve_notification_save_accuracy_summary">
+            <intent
+                android:action="android.intent.action.VIEW"
+                android:data="@string/line_privacy_url"/>
+        </Preference>
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Issue

close #46 


## Overview

- Add LINE privacy link on PreferenceScreen.
  - Throw intent with "https://line.me/R/nv/settings/privacy" data to LINE app.


## Screenshots

![Screenshot_20200528-153711_NotificationWatcher](https://user-images.githubusercontent.com/39234775/83107935-04bd3b80-a0fa-11ea-9e92-8c7cc2e1f962.jpg)
